### PR TITLE
Fix branch that the `Binder` badge link points to

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Binder will create a cloud environment with all the dependencies just for you!
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/poliastro/tutorial/master)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/poliastro/tutorial/main)
 
 ## Local installation
 


### PR DESCRIPTION
The badge url was pointing to `master`, so `Binder` was not able to load the project.

![Screenshot from 2021-03-20 20-36-43](https://user-images.githubusercontent.com/45886240/111883484-0a06b200-89bc-11eb-8a49-1073a9404ac8.png)
